### PR TITLE
Create kustomization-post-build.yaml

### DIFF
--- a/bases/patches/kustomization-post-build.yaml
+++ b/bases/patches/kustomization-post-build.yaml
@@ -1,0 +1,12 @@
+---
+apiVersion: kustomize.toolkit.fluxcd.io/v1beta2
+kind: Kustomization
+metadata:
+  name: flux
+  namespace: flux-giantswarm
+spec:
+  postBuild:
+    substitute:
+      # This field must be updated to match the prefix part of the repository created from this template:
+      # {customer_codename}-management-clusters, e.g.: example-management-clusters -> customer_codename: example
+      customer_codename: "CUSTOMER_CODENAME"


### PR DESCRIPTION
Towards: https://github.com/giantswarm/giantswarm/issues/26980
Related to: https://github.com/giantswarm/mc-bootstrap/pull/543

The value is updated via `mc-bootstrap`, for example:

```shell
yq '.spec.postBuild.substitute.customer_codename = "CUSTMER_CODENAME"' bases/patches/kustomization-post-build.yaml
```

### Please check if PR meets these requirements

- [ ] Critical resources are protected from accidental deletion by the [Flux annotations](https://fluxcd.io/flux/components/kustomize/kustomization/#garbage-collection).
- [ ] Results of the diffs have been examined and no unintended changes are being introduced.

### Helper

* to disable the GH Action generating manifests diffs for installations, between target and source branches, comment the `/no_diffs_printing` on the PR.
* to disable the GH Action for configuration drift detection in the `flux` Flux Kustomization CRs, between target and source branches, comment the `/no_drift_detection` on the PR.
