### PR TITLE
Delete bases/crds directory

### DIFF
--- a/bases/crds/kustomization.yaml
+++ b/bases/crds/kustomization.yaml
@@ -1,2 +1,0 @@
-resources:
-  - https://github.com/giantswarm/management-cluster-bases//bases/crds/all?ref=main


### PR DESCRIPTION
Towards: https://github.com/giantswarm/giantswarm/issues/27731

Related to: https://github.com/giantswarm/management-cluster-bases/pull/36
Related to: https://github.com/giantswarm/mc-bootstrap/pull/662

### Please check if PR meets these requirements

- [ ] Critical resources are protected from accidental deletion by the [Flux annotations](https://fluxcd.io/flux/components/kustomize/kustomization/#garbage-collection).
- [ ] Results of the diffs have been examined and no unintended changes are being introduced.

### Helper

* to disable the GH Action generating manifests diffs for installations, between target and source branches, comment the `/no_diffs_printing` on the PR.
* to disable the GH Action for configuration drift detection in the `flux` Flux Kustomization CRs, between target and source branches, comment the `/no_drift_detection` on the PR.
